### PR TITLE
fix: add for_update() option to WASM bindings and update docs

### DIFF
--- a/src/wasm/file.rs
+++ b/src/wasm/file.rs
@@ -13,10 +13,17 @@ use wasm_bindgen::prelude::*;
 /// # Example
 ///
 /// ```javascript
+/// // For read-only operations (memory efficient)
+/// const file = new XmpFile();
+/// file.from_bytes(data);
+/// const meta = file.get_xmp();
+///
+/// // For read and write operations
 /// const options = new ReadOptions();
-/// options.use_packet_scanning();
-/// options.limited_scanning();
+/// options.for_update();  // Required if you want to write changes
 /// file.from_bytes_with(data, options);
+/// // ... modify metadata ...
+/// const modifiedData = file.write_to_bytes();
 /// ```
 #[derive(Default)]
 #[wasm_bindgen]
@@ -30,6 +37,16 @@ impl ReadOptions {
     #[wasm_bindgen(constructor)]
     pub fn new() -> ReadOptions {
         ReadOptions::default()
+    }
+
+    /// Open for reading and writing
+    ///
+    /// This option is **required** if you want to use `write_to_bytes()` later.
+    /// When enabled, the original file data is stored in memory for later writing.
+    ///
+    /// If you only need to read XMP metadata, you can skip this option to save memory.
+    pub fn for_update(&mut self) {
+        self.inner = self.inner.for_update();
     }
 
     /// Force packet scanning (do not use smart handler)
@@ -68,14 +85,22 @@ impl ReadOptions {
 /// import init, { XmpFile, ReadOptions } from './pkg/xmpkit.js';
 /// await init();
 ///
+/// // Read-only mode (memory efficient)
 /// const file = new XmpFile();
 /// file.from_bytes(fileData);
 /// const meta = file.get_xmp();
-/// if (meta) {
-///     meta.set_property("http://ns.adobe.com/xap/1.0/", "CreatorTool", "MyApp");
-///     file.put_xmp(meta);
+///
+/// // Read and write mode
+/// const file2 = new XmpFile();
+/// const options = new ReadOptions();
+/// options.for_update();  // Required for write_to_bytes()
+/// file2.from_bytes_with(fileData, options);
+/// const meta2 = file2.get_xmp();
+/// if (meta2) {
+///     meta2.set_property("http://ns.adobe.com/xap/1.0/", "CreatorTool", "MyApp");
+///     file2.put_xmp(meta2);
 /// }
-/// const modifiedData = file.write_to_bytes();
+/// const modifiedData = file2.write_to_bytes();
 /// ```
 #[derive(Default)]
 #[wasm_bindgen]

--- a/web/e2e/vue.spec.ts
+++ b/web/e2e/vue.spec.ts
@@ -4,5 +4,6 @@ import { test, expect } from '@playwright/test';
 // https://playwright.dev/docs/intro
 test('visits the app root url', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('h1')).toHaveText('You did it!');
+  // The title can be either English or Chinese depending on browser locale
+  await expect(page.locator('h1')).toHaveText(/XMPKit WebAssembly Demo/);
 })

--- a/web/src/composables/useXmp.ts
+++ b/web/src/composables/useXmp.ts
@@ -142,6 +142,7 @@ export function useXmp() {
           let loadSuccess = false
           try {
             const options1 = new ReadOptions()
+            options1.for_update() // Required for write_to_bytes() later
             options1.use_smart_handler()
             options1.only_xmp()
             xmpFileInstance.from_bytes_with(fileData, options1)
@@ -150,6 +151,7 @@ export function useXmp() {
             console.log('Smart handler failed, trying packet scanning...', error)
             try {
               const options2 = new ReadOptions()
+              options2.for_update() // Required for write_to_bytes() later
               options2.use_packet_scanning()
               xmpFileInstance.from_bytes_with(fileData, options2)
               loadSuccess = true
@@ -348,6 +350,7 @@ export function useXmp() {
 
       try {
         const options1 = new ReadOptions()
+        options1.for_update() // Required for write_to_bytes() later
         options1.use_smart_handler()
         options1.only_xmp()
         xmpFileInstance.from_bytes_with(originalFileData.value, options1)
@@ -355,6 +358,7 @@ export function useXmp() {
       } catch {
         try {
           const options2 = new ReadOptions()
+          options2.for_update() // Required for write_to_bytes() later
           options2.use_packet_scanning()
           xmpFileInstance.from_bytes_with(originalFileData.value, options2)
           loadSuccess = true


### PR DESCRIPTION
## Summary

This is a follow-up to the streaming XMP read optimization (#31, #32).

- Add `for_update()` method to WASM `ReadOptions` binding to enable write operations
- Update web demo to use `for_update()` when loading files
- Fix WEBASSEMBLY.md documentation to reflect actual API
- Fix e2e test to check correct page title

## Changes

### WASM Bindings (`src/wasm/file.rs`)
- Added `for_update()` method to `ReadOptions`
- Updated documentation examples

### Web Demo (`web/src/composables/useXmp.ts`)
- Added `for_update()` calls in `loadFile` and `revertToOriginal` functions

### Documentation (`docs/WEBASSEMBLY.md`)
- Removed incorrect references to non-existent functions (`read_xmp`, `write_xmp`, `parse_xmp_packet`)
- Documented actual exported classes: `XmpFile`, `XmpMeta`, `ReadOptions`
- Updated all code examples to use class-based API with `for_update()`
- Added clear API reference section

### E2E Test (`web/e2e/vue.spec.ts`)
- Fixed test to check correct page title

## Test Plan

- [x] All Rust tests pass
- [x] WASM bindings compile correctly
- [x] Documentation examples are accurate