### PR TITLE
feat: add PDF file format support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +35,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -45,16 +71,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -71,6 +130,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -97,6 +167,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -131,6 +211,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -200,6 +304,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,10 +330,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dtor"
@@ -237,10 +370,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -263,6 +420,26 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -288,6 +465,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +528,47 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -335,10 +603,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lopdf"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+dependencies = [
+ "aes",
+ "bitflags",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom",
+ "indexmap",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5",
+ "nom",
+ "nom_locate",
+ "rand",
+ "rangemap",
+ "rayon",
+ "sha2",
+ "stringprep",
+ "thiserror",
+ "time",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "napi-build-ohos"
@@ -403,6 +729,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +814,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +886,41 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbbbbea733ec66275512d0b9694f34102e7d5406fdbe2ad8d21b28dce92887c"
 
 [[package]]
 name = "rayon"
@@ -644,10 +1061,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "syn"
@@ -694,6 +1139,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,16 +1180,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -790,6 +1320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,10 +1357,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -847,6 +1436,7 @@ version = "0.1.1"
 dependencies = [
  "criterion",
  "js-sys",
+ "lopdf",
  "napi-build-ohos",
  "napi-derive-ohos",
  "napi-ohos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["multimedia::images", "encoding"]
 
 [dependencies]
 quick-xml = { version = "0.38", features = ["serialize"], optional = true }
+lopdf = { version = "0.38", optional = true }
 thiserror = "2.0"
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }
@@ -33,6 +34,7 @@ gif = ["files"]
 jpeg = ["files"]
 mp3 = ["files"]
 mp4 = ["files"]
+pdf = ["files", "lopdf"]
 png = ["files"]
 tiff = ["files"]
 
@@ -47,7 +49,7 @@ optimize-file-layout = []
 mutli-thread = []
 
 # Enable all file format handlers support
-full-formats = ["gif", "jpeg", "mp3", "mp4", "png", "tiff"]
+full-formats = ["gif", "jpeg", "mp3", "mp4", "pdf", "png", "tiff"]
 
 # WebAssembly JavaScript bindings (optional)
 wasm = ["wasm-bindgen", "js-sys", "serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 MD041 MD036 -->
 <div align="center">
 
 # XMPKit
@@ -7,6 +8,7 @@
 </div>
 
 **Pure Rust implementation of Adobe XMP Toolkit**
+<!-- markdownlint-enable MD033 MD041 MD036 -->
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -32,7 +34,7 @@ XMPKit is a pure Rust implementation of Adobe's XMP (Extensible Metadata Platfor
 
 - Pure Rust implementation (no C++ dependencies)
 - Compatible with Adobe XMP standard
-- Support for common file formats (JPEG, PNG, TIFF, etc.)
+- Support for common file formats (JPEG, PNG, TIFF, GIF, MP3, MP4, PDF)
 - Memory safe and high performance
 - Zero-cost abstractions
 - Cross-platform support (iOS, Android, HarmonyOS, macOS, Windows, Linux, Wasm)
@@ -96,23 +98,25 @@ For WebAssembly/JavaScript integration, see [WEBASSEMBLY.md](docs/WEBASSEMBLY.md
 | TIFF | .tif, .tiff | Yes | Yes | Fully supported |
 | MP3 | .mp3 | Yes | Yes | Fully supported |
 | GIF | .gif | Yes | Yes | Fully supported |
-| MP4 | .mp4 | Yes | Yes | Fully supported |
-| PDF | .pdf | No | No | Planned |
+| MP4 | .mp4, .m4a, .m4v | Yes | Yes | Fully supported |
+| PDF | .pdf | Yes | Yes | Fully supported |
 | WebP | .webp | No | No | Planned |
 
 ### Platform Support
 
+<!-- markdownlint-disable MD056 -->
 | Platform | Architecture | File I/O | Memory I/O | Status |
 |----------|-------------|----------|------------|--------|
-| **Native Platforms** |
+| **Native Platforms** |||||
 | macOS | x86_64, arm64 | Yes | Yes | Fully supported |
 | Linux | x86_64, arm64 | Yes | Yes | Fully supported |
 | Windows | x86_64, arm64 | Yes | Yes | Fully supported |
 | iOS | arm64 | Yes | Yes | Fully supported |
 | Android | arm64, armv7, x86_64 | Yes | Yes | Fully supported |
 | HarmonyOS | arm64, armv7, x86_64 | Yes | Yes | Fully supported (use `ohos` feature for Node-API bindings) |
-| **Web Platforms** |
+| **Web Platforms** |||||
 | WebAssembly | wasm32 | No | Yes | Partial (use `from_bytes()` / `from_reader()`, see [WEBASSEMBLY](docs/WEBASSEMBLY.md)) |
+<!-- markdownlint-enable MD056 -->
 
 ## Contributing
 
@@ -122,8 +126,8 @@ Contributions are welcome! Please see [CONTRIBUTING.md](docs/CONTRIBUTING.md) fo
 
 This project is licensed under either of
 
-- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/examples/read_xmp.rs
+++ b/examples/read_xmp.rs
@@ -1,30 +1,7 @@
-// Copyright 2022 Adobe. All rights reserved.
-// This file is licensed to you under the Apache License,
-// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
-// or the MIT license (http://opensource.org/licenses/MIT),
-// at your option.
-
-// Unless required by applicable law or agreed to in writing,
-// this software is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
-// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
-// specific language governing permissions and limitations under
-// each license.
-
-// ------------------------------------------------------------
-
-// This application will accept a file path to a resource, open
-// the file as read-only, then read the XMP data from the file.
-// Once the XMP packet is available, it will access several
-// properties and print those values to stdout.
-
-// The application reads properties from three different schemas:
-// the XMP Basic schema, the Dublin Core schema, and the Exif
-// schema.
-
-// Based on the example titled "Creating the MyReadXMP application"
-// from XMP Toolkit SDK Programmer's Guide (pages 68-71 of the
-// February 2022 edition).
+//! Read XMP metadata from a file
+//!
+//! This example demonstrates how to read XMP metadata from various file formats.
+//! It reads properties from the XMP Basic, Dublin Core, and Exif schemas.
 
 use std::env;
 

--- a/examples/write_xmp.rs
+++ b/examples/write_xmp.rs
@@ -1,0 +1,130 @@
+//! Write XMP metadata to a file
+//!
+//! This example demonstrates how to write XMP metadata to various file formats.
+//! It writes properties to the Dublin Core, XMP Basic, and custom namespaces.
+
+use std::env;
+
+use xmpkit::{core::namespace::ns, register_namespace, ReadOptions, XmpFile, XmpMeta};
+
+fn write_xmp_to_file() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse command-line arguments.
+    // Expected: input_file output_file
+    let args: Vec<String> = env::args().collect();
+
+    let (input_path, output_path) = match args.len() {
+        3 => Ok((&args[1], &args[2])),
+        n => Err(format!(
+            "expected 2 arguments (input_file output_file), got {} arguments",
+            n - 1
+        )),
+    }?;
+
+    // Open the input file with for_update option (required for writing)
+    let mut xmp_file = XmpFile::new();
+    xmp_file.open_with(input_path, ReadOptions::default().for_update())?;
+
+    // Get existing XMP or create new metadata
+    let mut xmp = xmp_file.get_xmp().cloned().unwrap_or_else(XmpMeta::new);
+
+    // =========================================
+    // Set simple properties
+    // =========================================
+
+    // Set the creator tool (XMP Basic namespace)
+    xmp.set_property(ns::XMP, "CreatorTool", "XMPKit Example v1.0".into())?;
+
+    // Set the title (Dublin Core namespace) with localized text
+    xmp.set_localized_text(ns::DC, "title", "en", "en-US", "My Document Title")?;
+    xmp.set_localized_text(ns::DC, "title", "zh", "zh-CN", "我的文档标题")?;
+
+    // Set the description
+    xmp.set_localized_text(
+        ns::DC,
+        "description",
+        "en",
+        "en-US",
+        "This is a sample document with XMP metadata.",
+    )?;
+
+    // Set rights/copyright information
+    xmp.set_localized_text(ns::DC, "rights", "en", "en-US", "© 2024 Example Corp.")?;
+
+    // =========================================
+    // Set array properties
+    // =========================================
+
+    // Add creators (authors)
+    xmp.append_array_item(ns::DC, "creator", "John Doe".into())?;
+    xmp.append_array_item(ns::DC, "creator", "Jane Smith".into())?;
+
+    // Add keywords/subjects
+    xmp.append_array_item(ns::DC, "subject", "XMP".into())?;
+    xmp.append_array_item(ns::DC, "subject", "Metadata".into())?;
+    xmp.append_array_item(ns::DC, "subject", "Rust".into())?;
+    xmp.append_array_item(ns::DC, "subject", "Example".into())?;
+
+    // =========================================
+    // Set date properties
+    // =========================================
+
+    // Set creation and modification dates
+    // You can parse ISO 8601 date strings
+    let create_date = xmpkit::XmpDateTime::parse("2024-01-15T10:30:00+08:00")?;
+    let modify_date = xmpkit::XmpDateTime::parse("2024-12-09T14:00:00+08:00")?;
+    xmp.set_date_time(ns::XMP, "CreateDate", &create_date)?;
+    xmp.set_date_time(ns::XMP, "ModifyDate", &modify_date)?;
+    xmp.set_date_time(ns::XMP, "MetadataDate", &modify_date)?;
+
+    // =========================================
+    // Set struct properties
+    // =========================================
+
+    // Set a structured property (e.g., IPTC Creator Contact Info)
+    // First register the IPTC namespace if not already registered
+    let iptc_ext = "http://iptc.org/std/Iptc4xmpExt/2008-02-29/";
+    register_namespace(iptc_ext, "Iptc4xmpExt")?;
+
+    // =========================================
+    // Custom namespace example
+    // =========================================
+
+    // Register and use a custom namespace
+    let custom_ns = "http://example.com/myapp/1.0/";
+    register_namespace(custom_ns, "myapp")?;
+
+    xmp.set_property(custom_ns, "AppVersion", "2.0.1".into())?;
+    xmp.set_property(custom_ns, "DocumentType", "report".into())?;
+    xmp.set_property(custom_ns, "ProcessedBy", "XMPKit".into())?;
+
+    // =========================================
+    // Update the file
+    // =========================================
+
+    // Put the modified XMP back into the file
+    xmp_file.put_xmp(xmp);
+
+    // Save to the output file
+    xmp_file.save(output_path)?;
+
+    println!("Successfully wrote XMP metadata to: {}", output_path);
+    println!();
+    println!("Properties written:");
+    println!("  - xmp:CreatorTool");
+    println!("  - dc:title (en-US, zh-CN)");
+    println!("  - dc:description (en-US)");
+    println!("  - dc:rights (en-US)");
+    println!("  - dc:creator (array)");
+    println!("  - dc:subject (array)");
+    println!("  - xmp:CreateDate, xmp:ModifyDate, xmp:MetadataDate");
+    println!("  - myapp:AppVersion, myapp:DocumentType, myapp:ProcessedBy");
+
+    Ok(())
+}
+
+fn main() {
+    if let Err(err) = write_xmp_to_file() {
+        eprintln!("Error: {:?}", err);
+        std::process::exit(1);
+    }
+}

--- a/src/core/metadata/mod.rs
+++ b/src/core/metadata/mod.rs
@@ -218,6 +218,25 @@ impl XmpMeta {
         serializer.serialize_packet(&root)
     }
 
+    /// Serialize to XMP Packet format with padding to reach a target length
+    ///
+    /// This is useful for in-place updates where the new packet needs to fit
+    /// within the space of an existing packet.
+    ///
+    /// # Arguments
+    ///
+    /// * `target_length` - The desired total packet length in bytes
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(String)` - The serialized packet with padding
+    /// * `Err(XmpError)` - If the serialized packet exceeds target_length
+    pub fn serialize_packet_with_padding(&self, target_length: usize) -> XmpResult<String> {
+        let serializer = XmpSerializer::new();
+        let root = root_read!(self.root);
+        serializer.serialize_packet_with_padding(&root, target_length)
+    }
+
     /// Get an array item by index
     ///
     /// # Arguments

--- a/src/files/formats/mod.rs
+++ b/src/files/formats/mod.rs
@@ -12,6 +12,8 @@ pub mod jpeg;
 pub mod mp3;
 #[cfg(feature = "mp4")]
 pub mod mp4;
+#[cfg(feature = "pdf")]
+pub mod pdf;
 #[cfg(feature = "png")]
 pub mod png;
 #[cfg(feature = "tiff")]

--- a/src/files/formats/pdf.rs
+++ b/src/files/formats/pdf.rs
@@ -1,0 +1,462 @@
+//! PDF file format handler
+//!
+//! This module provides functionality for reading and writing XMP metadata
+//! in PDF files. The implementation is pure Rust and cross-platform compatible.
+//!
+//! PDF XMP Storage:
+//! - XMP is stored in a Metadata stream object in the document catalog
+//! - The XMP packet is embedded with standard markers:
+//!   `<?xpacket begin="..." id="W5M0MpCehiHzreSzNTczkc9d"?>` ... `<?xpacket end="w"?>`
+//!
+//! Reference: Adobe XMP Specification Part 3 - Storage in Files
+
+use crate::core::error::{XmpError, XmpResult};
+use crate::core::metadata::XmpMeta;
+use crate::files::handler::FileHandler;
+use lopdf::{dictionary, Document, Object, Stream};
+use std::io::{Read, Seek, Write};
+
+/// PDF file signature
+const PDF_SIGNATURE: &[u8] = b"%PDF-";
+
+/// PDF file handler for XMP metadata
+#[derive(Debug, Clone, Copy)]
+pub struct PdfHandler;
+
+impl FileHandler for PdfHandler {
+    fn can_handle<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<bool> {
+        let mut header = [0u8; 5];
+        if reader.read_exact(&mut header).is_err() {
+            reader.rewind()?;
+            return Ok(false);
+        }
+        reader.rewind()?;
+        Ok(header == PDF_SIGNATURE)
+    }
+
+    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>> {
+        Self::read_xmp(reader)
+    }
+
+    fn write_xmp<R: Read + Seek, W: Write + Seek>(
+        &self,
+        reader: &mut R,
+        writer: &mut W,
+        meta: &XmpMeta,
+    ) -> XmpResult<()> {
+        Self::write_xmp(reader, writer, meta)
+    }
+
+    fn format_name(&self) -> &'static str {
+        "PDF"
+    }
+
+    fn extensions(&self) -> &'static [&'static str] {
+        &["pdf"]
+    }
+}
+
+impl PdfHandler {
+    /// Read XMP metadata from a PDF file
+    ///
+    /// Uses lopdf to properly parse the PDF structure and extract XMP metadata
+    /// from the document catalog's Metadata stream.
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - A reader implementing `Read + Seek`
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(XmpMeta))` if XMP metadata is found
+    /// * `Ok(None)` if no XMP metadata is found
+    /// * `Err(XmpError)` if an error occurs
+    pub fn read_xmp<R: Read + Seek>(mut reader: R) -> XmpResult<Option<XmpMeta>> {
+        // Load the PDF document
+        let doc = Document::load_from(&mut reader).map_err(|e| {
+            XmpError::IoError(std::io::Error::other(format!("Failed to load PDF: {}", e)))
+        })?;
+
+        // Get the catalog dictionary
+        let catalog = doc.catalog().map_err(|e| {
+            XmpError::IoError(std::io::Error::other(format!(
+                "Failed to get PDF catalog: {}",
+                e
+            )))
+        })?;
+
+        // Look for Metadata reference in catalog
+        let metadata_ref = match catalog.get(b"Metadata") {
+            Ok(obj) => match obj.as_reference() {
+                Ok(r) => r,
+                Err(_) => return Ok(None), // Metadata exists but is not a reference
+            },
+            Err(_) => return Ok(None), // No Metadata in catalog
+        };
+
+        // Get the metadata stream object
+        let metadata_obj = doc.get_object(metadata_ref).map_err(|e| {
+            XmpError::IoError(std::io::Error::other(format!(
+                "Failed to get metadata object: {}",
+                e
+            )))
+        })?;
+
+        // Extract the stream content
+        let xmp_bytes = match metadata_obj {
+            Object::Stream(ref stream) => {
+                // Try to get decompressed content first, fallback to raw content
+                // XMP streams are typically not compressed
+                stream
+                    .decompressed_content()
+                    .unwrap_or_else(|_| stream.content.clone())
+            }
+            _ => return Ok(None), // Metadata is not a stream
+        };
+
+        // Convert to string and parse XMP
+        let xmp_str = String::from_utf8(xmp_bytes)
+            .map_err(|e| XmpError::ParseError(format!("Invalid UTF-8 in XMP: {}", e)))?;
+
+        // Handle empty XMP
+        if xmp_str.trim().is_empty() {
+            return Ok(None);
+        }
+
+        XmpMeta::parse(&xmp_str).map(Some)
+    }
+
+    /// Write XMP metadata to a PDF file
+    ///
+    /// Uses lopdf to properly modify the PDF structure:
+    /// - If the PDF has existing XMP metadata, it updates the metadata stream
+    /// - If the PDF has no XMP metadata, it creates a new metadata stream
+    ///   and adds a reference to it in the document catalog
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - A reader for the source PDF
+    /// * `writer` - A writer for the output PDF
+    /// * `meta` - The XMP metadata to write
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` on success
+    /// * `Err(XmpError)` if an error occurs
+    pub fn write_xmp<R: Read + Seek, W: Write + Seek>(
+        mut reader: R,
+        mut writer: W,
+        meta: &XmpMeta,
+    ) -> XmpResult<()> {
+        // Load the PDF document
+        let mut doc = Document::load_from(&mut reader).map_err(|e| {
+            XmpError::IoError(std::io::Error::other(format!("Failed to load PDF: {}", e)))
+        })?;
+
+        // Serialize XMP to packet format
+        let xmp_packet = meta.serialize_packet()?;
+        let xmp_bytes = xmp_packet.into_bytes();
+
+        // Create the metadata stream
+        let metadata_stream = Stream::new(
+            dictionary! {
+                "Type" => "Metadata",
+                "Subtype" => "XML",
+            },
+            xmp_bytes,
+        );
+
+        // Get catalog object ID
+        let catalog_id = doc.catalog().map_err(|e| {
+            XmpError::IoError(std::io::Error::other(format!(
+                "Failed to get PDF catalog: {}",
+                e
+            )))
+        })?;
+
+        // Check if there's an existing Metadata reference
+        let existing_metadata_ref = catalog_id
+            .get(b"Metadata")
+            .ok()
+            .and_then(|obj| obj.as_reference().ok());
+
+        let metadata_id = if let Some(ref_id) = existing_metadata_ref {
+            // Update existing metadata object
+            doc.objects.insert(ref_id, Object::Stream(metadata_stream));
+            ref_id
+        } else {
+            // Add new metadata object
+            doc.add_object(Object::Stream(metadata_stream))
+        };
+
+        // Update catalog to reference metadata
+        let catalog_obj_id = doc
+            .trailer
+            .get(b"Root")
+            .map_err(|e| {
+                XmpError::IoError(std::io::Error::other(format!("Failed to get Root: {}", e)))
+            })?
+            .as_reference()
+            .map_err(|e| {
+                XmpError::IoError(std::io::Error::other(format!(
+                    "Root is not a reference: {}",
+                    e
+                )))
+            })?;
+
+        if let Some(Object::Dictionary(ref mut catalog_dict)) = doc.objects.get_mut(&catalog_obj_id)
+        {
+            catalog_dict.set("Metadata", Object::Reference(metadata_id));
+        }
+
+        // Save the modified document
+        doc.save_to(&mut writer).map_err(|e| {
+            XmpError::IoError(std::io::Error::other(format!("Failed to save PDF: {}", e)))
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Create a minimal valid PDF using lopdf
+    fn create_minimal_pdf() -> Vec<u8> {
+        let mut doc = Document::with_version("1.4");
+
+        // Create a minimal page
+        let pages_id = doc.new_object_id();
+        let page_id = doc.new_object_id();
+
+        let page = dictionary! {
+            "Type" => "Page",
+            "Parent" => Object::Reference(pages_id),
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        };
+        doc.objects.insert(page_id, Object::Dictionary(page));
+
+        let pages = dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::Reference(page_id)],
+            "Count" => 1,
+        };
+        doc.objects.insert(pages_id, Object::Dictionary(pages));
+
+        // Create catalog
+        let catalog_id = doc.new_object_id();
+        let catalog = dictionary! {
+            "Type" => "Catalog",
+            "Pages" => Object::Reference(pages_id),
+        };
+        doc.objects.insert(catalog_id, Object::Dictionary(catalog));
+
+        // Set trailer
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let mut buffer = Vec::new();
+        doc.save_to(&mut buffer).unwrap();
+        buffer
+    }
+
+    /// Create a PDF with XMP metadata using lopdf
+    fn create_pdf_with_xmp(xmp: &str) -> Vec<u8> {
+        let mut doc = Document::with_version("1.4");
+
+        // Create a minimal page
+        let pages_id = doc.new_object_id();
+        let page_id = doc.new_object_id();
+
+        let page = dictionary! {
+            "Type" => "Page",
+            "Parent" => Object::Reference(pages_id),
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        };
+        doc.objects.insert(page_id, Object::Dictionary(page));
+
+        let pages = dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::Reference(page_id)],
+            "Count" => 1,
+        };
+        doc.objects.insert(pages_id, Object::Dictionary(pages));
+
+        // Create metadata stream
+        let metadata_stream = Stream::new(
+            dictionary! {
+                "Type" => "Metadata",
+                "Subtype" => "XML",
+            },
+            xmp.as_bytes().to_vec(),
+        );
+        let metadata_id = doc.add_object(Object::Stream(metadata_stream));
+
+        // Create catalog with metadata reference
+        let catalog_id = doc.new_object_id();
+        let catalog = dictionary! {
+            "Type" => "Catalog",
+            "Pages" => Object::Reference(pages_id),
+            "Metadata" => Object::Reference(metadata_id),
+        };
+        doc.objects.insert(catalog_id, Object::Dictionary(catalog));
+
+        // Set trailer
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let mut buffer = Vec::new();
+        doc.save_to(&mut buffer).unwrap();
+        buffer
+    }
+
+    fn create_minimal_xmp_packet() -> String {
+        r#"<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+      <dc:title>Test PDF</dc:title>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>"#
+            .to_string()
+    }
+
+    #[test]
+    fn test_can_handle_pdf() {
+        let pdf_data = create_minimal_pdf();
+        let mut reader = Cursor::new(pdf_data);
+        let handler = PdfHandler;
+        assert!(handler.can_handle(&mut reader).unwrap());
+    }
+
+    #[test]
+    fn test_can_handle_non_pdf() {
+        let handler = PdfHandler;
+
+        // JPEG file (need at least 5 bytes to compare with PDF signature)
+        let jpeg_data = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        let mut reader = Cursor::new(jpeg_data);
+        assert!(!handler.can_handle(&mut reader).unwrap());
+
+        // PNG file
+        let png_data = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let mut reader = Cursor::new(png_data);
+        assert!(!handler.can_handle(&mut reader).unwrap());
+
+        // Empty file
+        let empty_data: Vec<u8> = vec![];
+        let mut reader = Cursor::new(empty_data);
+        assert!(!handler.can_handle(&mut reader).unwrap());
+
+        // Short file
+        let short_data = vec![0x25, 0x50]; // "%P"
+        let mut reader = Cursor::new(short_data);
+        assert!(!handler.can_handle(&mut reader).unwrap());
+    }
+
+    #[test]
+    fn test_read_xmp_from_pdf() {
+        let xmp_packet = create_minimal_xmp_packet();
+        let pdf_data = create_pdf_with_xmp(&xmp_packet);
+        let reader = Cursor::new(pdf_data);
+
+        let result = PdfHandler::read_xmp(reader).unwrap();
+        assert!(result.is_some());
+
+        let meta = result.unwrap();
+        let title = meta.get_property(crate::core::namespace::ns::DC, "title");
+        assert!(title.is_some());
+    }
+
+    #[test]
+    fn test_read_xmp_no_xmp() {
+        // PDF without XMP
+        let pdf_data = create_minimal_pdf();
+        let reader = Cursor::new(pdf_data);
+
+        let result = PdfHandler::read_xmp(reader).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_write_xmp_to_pdf_with_existing_xmp() {
+        // Create PDF with XMP
+        let original_xmp = create_minimal_xmp_packet();
+        let pdf_data = create_pdf_with_xmp(&original_xmp);
+
+        // Create new metadata
+        let mut new_meta = XmpMeta::new();
+        let _ = new_meta.set_property(
+            crate::core::namespace::ns::DC,
+            "title",
+            "Updated Title".into(),
+        );
+        let _ = new_meta.set_property(
+            crate::core::namespace::ns::DC,
+            "creator",
+            "Test Author".into(),
+        );
+
+        // Write XMP
+        let reader = Cursor::new(pdf_data);
+        let mut output = Cursor::new(Vec::new());
+        PdfHandler::write_xmp(reader, &mut output, &new_meta).unwrap();
+
+        // Read back and verify
+        output.set_position(0);
+        let result = PdfHandler::read_xmp(&mut output).unwrap();
+        assert!(result.is_some());
+
+        let meta = result.unwrap();
+        let title = meta.get_property(crate::core::namespace::ns::DC, "title");
+        assert_eq!(
+            title.and_then(|v| v.as_str().map(|s| s.to_string())),
+            Some("Updated Title".to_string())
+        );
+    }
+
+    #[test]
+    fn test_write_xmp_to_pdf_without_existing_xmp() {
+        // Create PDF without XMP
+        let pdf_data = create_minimal_pdf();
+
+        // Create new metadata
+        let mut new_meta = XmpMeta::new();
+        let _ = new_meta.set_property(crate::core::namespace::ns::DC, "title", "New Title".into());
+
+        // Write XMP
+        let reader = Cursor::new(pdf_data);
+        let mut output = Cursor::new(Vec::new());
+        PdfHandler::write_xmp(reader, &mut output, &new_meta).unwrap();
+
+        // Read back and verify
+        output.set_position(0);
+        let result = PdfHandler::read_xmp(&mut output).unwrap();
+        assert!(result.is_some());
+
+        let meta = result.unwrap();
+        let title = meta.get_property(crate::core::namespace::ns::DC, "title");
+        assert_eq!(
+            title.and_then(|v| v.as_str().map(|s| s.to_string())),
+            Some("New Title".to_string())
+        );
+    }
+
+    #[test]
+    fn test_invalid_pdf() {
+        let invalid_data = vec![0x00, 0x01, 0x02, 0x03, 0x04];
+        let reader = Cursor::new(invalid_data);
+        let result = PdfHandler::read_xmp(reader);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_info() {
+        let handler = PdfHandler;
+        assert_eq!(handler.format_name(), "PDF");
+        assert_eq!(handler.extensions(), &["pdf"]);
+    }
+}

--- a/src/files/registry.rs
+++ b/src/files/registry.rs
@@ -19,6 +19,8 @@ pub enum Handler {
     Mp3(crate::files::formats::mp3::Mp3Handler),
     #[cfg(feature = "mp4")]
     Mp4(crate::files::formats::mp4::Mp4Handler),
+    #[cfg(feature = "pdf")]
+    Pdf(crate::files::formats::pdf::PdfHandler),
     #[cfg(feature = "png")]
     Png(crate::files::formats::png::PngHandler),
     #[cfg(feature = "tiff")]
@@ -36,6 +38,8 @@ impl FileHandler for Handler {
             Handler::Mp3(h) => h.can_handle(reader),
             #[cfg(feature = "mp4")]
             Handler::Mp4(h) => h.can_handle(reader),
+            #[cfg(feature = "pdf")]
+            Handler::Pdf(h) => h.can_handle(reader),
             #[cfg(feature = "png")]
             Handler::Png(h) => h.can_handle(reader),
             #[cfg(feature = "tiff")]
@@ -56,6 +60,8 @@ impl FileHandler for Handler {
             Handler::Mp3(h) => h.read_xmp(reader),
             #[cfg(feature = "mp4")]
             Handler::Mp4(h) => h.read_xmp(reader),
+            #[cfg(feature = "pdf")]
+            Handler::Pdf(h) => h.read_xmp(reader),
             #[cfg(feature = "png")]
             Handler::Png(h) => h.read_xmp(reader),
             #[cfg(feature = "tiff")]
@@ -78,6 +84,8 @@ impl FileHandler for Handler {
             Handler::Mp3(h) => h.write_xmp(reader, writer, meta),
             #[cfg(feature = "mp4")]
             Handler::Mp4(h) => h.write_xmp(reader, writer, meta),
+            #[cfg(feature = "pdf")]
+            Handler::Pdf(h) => h.write_xmp(reader, writer, meta),
             #[cfg(feature = "png")]
             Handler::Png(h) => h.write_xmp(reader, writer, meta),
             #[cfg(feature = "tiff")]
@@ -95,6 +103,8 @@ impl FileHandler for Handler {
             Handler::Mp3(h) => h.format_name(),
             #[cfg(feature = "mp4")]
             Handler::Mp4(h) => h.format_name(),
+            #[cfg(feature = "pdf")]
+            Handler::Pdf(h) => h.format_name(),
             #[cfg(feature = "png")]
             Handler::Png(h) => h.format_name(),
             #[cfg(feature = "tiff")]
@@ -112,6 +122,8 @@ impl FileHandler for Handler {
             Handler::Mp3(h) => h.extensions(),
             #[cfg(feature = "mp4")]
             Handler::Mp4(h) => h.extensions(),
+            #[cfg(feature = "pdf")]
+            Handler::Pdf(h) => h.extensions(),
             #[cfg(feature = "png")]
             Handler::Png(h) => h.extensions(),
             #[cfg(feature = "tiff")]
@@ -140,7 +152,7 @@ impl HandlerRegistry {
         self.handlers.push(handler);
     }
 
-    /// Register default handlers (GIF, JPEG, MP3, MP4, PNG, TIFF)
+    /// Register default handlers (GIF, JPEG, MP3, MP4, PDF, PNG, TIFF)
     fn register_defaults(&mut self) {
         #[cfg(feature = "gif")]
         self.register(Handler::Gif(crate::files::formats::gif::GifHandler));
@@ -150,6 +162,8 @@ impl HandlerRegistry {
         self.register(Handler::Mp3(crate::files::formats::mp3::Mp3Handler));
         #[cfg(feature = "mp4")]
         self.register(Handler::Mp4(crate::files::formats::mp4::Mp4Handler));
+        #[cfg(feature = "pdf")]
+        self.register(Handler::Pdf(crate::files::formats::pdf::PdfHandler));
         #[cfg(feature = "png")]
         self.register(Handler::Png(crate::files::formats::png::PngHandler));
         #[cfg(feature = "tiff")]
@@ -236,12 +250,57 @@ mod tests {
     #[test]
     fn test_find_by_extension() {
         let registry = HandlerRegistry::new();
-        assert!(registry.find_by_extension("jpg").is_some());
+
+        // Test all supported extensions
+        #[cfg(feature = "gif")]
+        assert!(registry.find_by_extension("gif").is_some());
+
+        #[cfg(feature = "jpeg")]
+        {
+            assert!(registry.find_by_extension("jpg").is_some());
+            assert!(registry.find_by_extension("jpeg").is_some());
+        }
+
+        #[cfg(feature = "mp3")]
+        assert!(registry.find_by_extension("mp3").is_some());
+
+        #[cfg(feature = "mp4")]
+        {
+            assert!(registry.find_by_extension("mp4").is_some());
+            assert!(registry.find_by_extension("m4a").is_some());
+            assert!(registry.find_by_extension("m4v").is_some());
+        }
+
+        #[cfg(feature = "pdf")]
+        assert!(registry.find_by_extension("pdf").is_some());
+
+        #[cfg(feature = "png")]
         assert!(registry.find_by_extension("png").is_some());
-        assert!(registry.find_by_extension("tiff").is_some());
+
+        #[cfg(feature = "tiff")]
+        {
+            assert!(registry.find_by_extension("tif").is_some());
+            assert!(registry.find_by_extension("tiff").is_some());
+        }
+
+        // Unknown extension
         assert!(registry.find_by_extension("unknown").is_none());
+        assert!(registry.find_by_extension("xyz").is_none());
     }
 
+    #[cfg(feature = "gif")]
+    #[test]
+    fn test_find_by_detection_gif() {
+        let registry = HandlerRegistry::new();
+        // GIF89a signature
+        let gif_data = vec![0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00, 0x00];
+        let mut reader = Cursor::new(gif_data);
+        let handler = registry.find_by_detection(&mut reader).unwrap();
+        assert!(handler.is_some());
+        assert_eq!(handler.unwrap().format_name(), "GIF");
+    }
+
+    #[cfg(feature = "jpeg")]
     #[test]
     fn test_find_by_detection_jpeg() {
         let registry = HandlerRegistry::new();
@@ -252,6 +311,50 @@ mod tests {
         assert_eq!(handler.unwrap().format_name(), "JPEG");
     }
 
+    #[cfg(feature = "mp3")]
+    #[test]
+    fn test_find_by_detection_mp3() {
+        let registry = HandlerRegistry::new();
+        // ID3v2 signature
+        let mp3_data = vec![0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let mut reader = Cursor::new(mp3_data);
+        let handler = registry.find_by_detection(&mut reader).unwrap();
+        assert!(handler.is_some());
+        assert_eq!(handler.unwrap().format_name(), "MP3");
+    }
+
+    #[cfg(feature = "mp4")]
+    #[test]
+    fn test_find_by_detection_mp4() {
+        let registry = HandlerRegistry::new();
+        // MP4 ftyp box signature
+        let mp4_data = vec![
+            0x00, 0x00, 0x00, 0x18, // box size
+            0x66, 0x74, 0x79, 0x70, // 'ftyp'
+            0x69, 0x73, 0x6F, 0x6D, // 'isom'
+            0x00, 0x00, 0x00, 0x00, // minor version
+            0x69, 0x73, 0x6F, 0x6D, // compatible brand
+            0x61, 0x76, 0x63, 0x31, // compatible brand
+        ];
+        let mut reader = Cursor::new(mp4_data);
+        let handler = registry.find_by_detection(&mut reader).unwrap();
+        assert!(handler.is_some());
+        assert_eq!(handler.unwrap().format_name(), "MP4");
+    }
+
+    #[cfg(feature = "pdf")]
+    #[test]
+    fn test_find_by_detection_pdf() {
+        let registry = HandlerRegistry::new();
+        // PDF signature
+        let pdf_data = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n".to_vec();
+        let mut reader = Cursor::new(pdf_data);
+        let handler = registry.find_by_detection(&mut reader).unwrap();
+        assert!(handler.is_some());
+        assert_eq!(handler.unwrap().format_name(), "PDF");
+    }
+
+    #[cfg(feature = "png")]
     #[test]
     fn test_find_by_detection_png() {
         let registry = HandlerRegistry::new();
@@ -260,5 +363,39 @@ mod tests {
         let handler = registry.find_by_detection(&mut reader).unwrap();
         assert!(handler.is_some());
         assert_eq!(handler.unwrap().format_name(), "PNG");
+    }
+
+    #[cfg(feature = "tiff")]
+    #[test]
+    fn test_find_by_detection_tiff_le() {
+        let registry = HandlerRegistry::new();
+        // TIFF little-endian signature
+        let tiff_data = vec![0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00];
+        let mut reader = Cursor::new(tiff_data);
+        let handler = registry.find_by_detection(&mut reader).unwrap();
+        assert!(handler.is_some());
+        assert_eq!(handler.unwrap().format_name(), "TIFF");
+    }
+
+    #[cfg(feature = "tiff")]
+    #[test]
+    fn test_find_by_detection_tiff_be() {
+        let registry = HandlerRegistry::new();
+        // TIFF big-endian signature
+        let tiff_data = vec![0x4D, 0x4D, 0x00, 0x2A, 0x00, 0x00, 0x00, 0x08];
+        let mut reader = Cursor::new(tiff_data);
+        let handler = registry.find_by_detection(&mut reader).unwrap();
+        assert!(handler.is_some());
+        assert_eq!(handler.unwrap().format_name(), "TIFF");
+    }
+
+    #[test]
+    fn test_find_by_detection_unknown() {
+        let registry = HandlerRegistry::new();
+        // Random data that doesn't match any format
+        let unknown_data = vec![0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let mut reader = Cursor::new(unknown_data);
+        let handler = registry.find_by_detection(&mut reader).unwrap();
+        assert!(handler.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! - Pure Rust implementation
 //! - Compatible with Adobe XMP standard
-//! - Support for common file formats (JPEG, PNG, TIFF, MP3, GIF, MP4)
+//! - Support for common file formats (e.g., JPEG, PNG, TIFF, MP3, GIF, MP4)
 //! - Memory safe and high performance
 //! - Cross-platform support (iOS, Android, HarmonyOS, macOS, Windows, Linux, Wasm)
 //!


### PR DESCRIPTION
## Summary

- Add PDF handler with full read/write XMP metadata support using [lopdf](https://github.com/J-F-Liu/lopdf) library
- Implement proper PDF structure parsing (Catalog → Metadata stream)
- Support both updating existing XMP and creating new XMP in PDFs without existing metadata

## Changes

### New Features
- `src/files/formats/pdf.rs` - PDF file handler implementation
- `examples/write_xmp.rs` - Example demonstrating XMP metadata writing

### Enhancements
- `serialize_packet_with_padding()` method for XMP packet sizing control
- Comprehensive tests for all file format handlers in registry
- Clean up examples (remove Adobe copyright, use Rust doc comments)
- Update README with PDF support status

### Dependencies
- Add `lopdf = "0.38"` as optional dependency for PDF feature

## Test plan

- [x] `cargo test --features pdf` - All PDF tests pass
- [x] `cargo test --features full-formats` - All format tests pass
- [x] `cargo clippy --features full-formats` - No warnings
- [x] Manual test with real PDF files