### PR TITLE
chore: optimize dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,92 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  # Workflow files stored in the
-  # default location of `.github/workflows`
-  directory: "/"
-  schedule:
-    interval: "daily"
-  commit-message:
-    prefix: "chore(ci):"
-    include: scope
+  # GitHub Actions - weekly check is enough
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci):"
+      include: scope
 
-- package-ecosystem: "cargo"
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "08:00"
-  open-pull-requests-limit: 10
-  commit-message:
-    prefix: "chore(deps):"
-    include: scope
+  # Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    groups:
+      # Group all minor/patch updates together
+      rust-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Major updates will still be individual PRs
+    commit-message:
+      prefix: "chore(deps):"
+      include: scope
 
-- package-ecosystem: "npm"
-  directory: "/web"
-  schedule:
-    interval: "weekly"
-  commit-message:
-    prefix: "chore(deps):"
+  # npm dependencies for web demo
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    groups:
+      # Vue ecosystem updates together
+      vue-ecosystem:
+        patterns:
+          - "vue*"
+          - "@vue/*"
+          - "pinia"
+          - "vue-router"
+          - "vue-i18n"
+        update-types:
+          - "minor"
+          - "patch"
+      # Build tools together
+      build-tools:
+        patterns:
+          - "vite*"
+          - "@vitejs/*"
+          - "typescript"
+          - "vue-tsc"
+        update-types:
+          - "minor"
+          - "patch"
+      # Testing tools together
+      testing:
+        patterns:
+          - "@playwright/*"
+          - "vitest"
+          - "@vitest/*"
+          - "jsdom"
+        update-types:
+          - "minor"
+          - "patch"
+      # ESLint ecosystem together
+      linting:
+        patterns:
+          - "eslint*"
+          - "@vue/eslint-*"
+        update-types:
+          - "minor"
+          - "patch"
+      # All other minor/patch updates
+      other-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps):"
+      include: scope


### PR DESCRIPTION
## Summary

Optimize Dependabot configuration to reduce PR noise based on [GitHub documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates).

## Changes

### Frequency Adjustments
| Ecosystem | Before | After |
|-----------|--------|-------|
| GitHub Actions | daily | weekly |
| Cargo | daily | weekly (Monday 08:00 CST) |
| npm | weekly | monthly (Monday 08:00 CST) |

### Grouping Strategy
- **Cargo**: Group all minor/patch updates together (major updates remain individual)
- **npm**: Group by category:
  - `vue-ecosystem`: Vue, Pinia, Vue Router, Vue I18n
  - `build-tools`: Vite, TypeScript, vue-tsc
  - `testing`: Playwright, Vitest, jsdom
  - `linting`: ESLint and plugins
  - `other-dependencies`: Everything else

### Other Optimizations
- Reduce `open-pull-requests-limit` to 5
- Add timezone configuration (Asia/Shanghai)
- Major updates still create individual PRs for careful review

## Expected Result
- Fewer, more meaningful PRs
- Grouped updates reduce review overhead
- Monthly npm checks align with demo site maintenance cadence