### PR TITLE
refactor: rename mp4 feature to mpeg4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,14 +33,14 @@ files = ["core"]
 gif = ["files"]
 jpeg = ["files"]
 mp3 = ["files"]
-mp4 = ["files"]
+mpeg4 = ["files"]
 pdf = ["files", "lopdf"]
 png = ["files"]
 tiff = ["files"]
 
 # Enable file layout optimization
-# Default: optimize-file-layout disabled - uses append mode (e.g., MP4: UUID box at end of file)
-# Enable this feature to optimize file layout for streaming (e.g., MP4: UUID box after moov, before mdat)
+# Default: optimize-file-layout disabled - uses append mode (e.g., MPEG4: UUID box at end of file)
+# Enable this feature to optimize file layout for streaming (e.g., MPEG4: UUID box after moov, before mdat)
 optimize-file-layout = []
 
 # Enable multi-threaded runtime support
@@ -49,7 +49,7 @@ optimize-file-layout = []
 mutli-thread = []
 
 # Enable all file format handlers support
-full-formats = ["gif", "jpeg", "mp3", "mp4", "pdf", "png", "tiff"]
+full-formats = ["gif", "jpeg", "mp3", "mpeg4", "pdf", "png", "tiff"]
 
 # WebAssembly JavaScript bindings (optional)
 wasm = ["wasm-bindgen", "js-sys", "serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ XMPKit is a pure Rust implementation of Adobe's XMP (Extensible Metadata Platfor
 
 - Pure Rust implementation (no C++ dependencies)
 - Compatible with Adobe XMP standard
-- Support for common file formats (JPEG, PNG, TIFF, GIF, MP3, MP4, PDF)
+- Support for common file formats (JPEG, PNG, TIFF, GIF, MP3, MPEG4, PDF)
 - Memory safe and high performance
 - Zero-cost abstractions
 - Cross-platform support (iOS, Android, HarmonyOS, macOS, Windows, Linux, Wasm)
@@ -98,7 +98,7 @@ For WebAssembly/JavaScript integration, see [WEBASSEMBLY.md](docs/WEBASSEMBLY.md
 | TIFF | .tif, .tiff | Yes | Yes | Fully supported |
 | MP3 | .mp3 | Yes | Yes | Fully supported |
 | GIF | .gif | Yes | Yes | Fully supported |
-| MP4 | .mp4, .m4a, .m4v | Yes | Yes | Fully supported |
+| MPEG4 | .mp4, .m4a, .m4v | Yes | Yes | Fully supported |
 | PDF | .pdf | Yes | Yes | Fully supported |
 | WebP | .webp | No | No | Planned |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ The files module (`src/files/`) provides file format support:
 - **TIFF**: IFD tags for XMP
 - **MP3**: ID3v2 PRIV frame for XMP
 - **GIF**: Application Extension for XMP
-- **MP4**: UUID box for XMP
+- **MPEG4**: UUID box for XMP
 
 ## Design Principles
 

--- a/src/files/formats/mod.rs
+++ b/src/files/formats/mod.rs
@@ -10,8 +10,8 @@ pub mod gif;
 pub mod jpeg;
 #[cfg(feature = "mp3")]
 pub mod mp3;
-#[cfg(feature = "mp4")]
-pub mod mp4;
+#[cfg(feature = "mpeg4")]
+pub mod mpeg4;
 #[cfg(feature = "pdf")]
 pub mod pdf;
 #[cfg(feature = "png")]

--- a/src/files/formats/mpeg4.rs
+++ b/src/files/formats/mpeg4.rs
@@ -29,9 +29,9 @@ const BOX_TYPE_UUID: &[u8] = b"uuid";
 
 /// MP4 file handler for XMP metadata
 #[derive(Debug, Clone, Copy)]
-pub struct Mp4Handler;
+pub struct Mpeg4Handler;
 
-impl FileHandler for Mp4Handler {
+impl FileHandler for Mpeg4Handler {
     fn can_handle<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<bool> {
         // MP4 file format: first 4 bytes are box size, next 4 bytes are box type "ftyp"
         let pos = reader.stream_position()?;
@@ -84,7 +84,7 @@ impl FileHandler for Mp4Handler {
 }
 
 #[derive(Debug)]
-struct Mp4Box {
+struct Mpeg4Box {
     size: u64,
     box_type: [u8; 4],
     #[allow(dead_code)]
@@ -101,7 +101,7 @@ struct BoxLayoutInfo {
     new_offset: u64,
 }
 
-impl Mp4Handler {
+impl Mpeg4Handler {
     /// Read XMP metadata from an MP4 file
     ///
     /// # Arguments
@@ -261,7 +261,7 @@ impl Mp4Handler {
     /// Read XMP from UUID box if it matches XMP UUID
     fn read_xmp_from_uuid_box<R: Read + Seek>(
         reader: &mut R,
-        box_info: &Mp4Box,
+        box_info: &Mpeg4Box,
     ) -> XmpResult<Option<XmpMeta>> {
         // Read UUID (16 bytes)
         let mut uuid = [0u8; 16];
@@ -285,7 +285,7 @@ impl Mp4Handler {
     }
 
     /// Read an MP4 box header
-    fn read_box<R: Read + Seek>(reader: &mut R) -> std::io::Result<Mp4Box> {
+    fn read_box<R: Read + Seek>(reader: &mut R) -> std::io::Result<Mpeg4Box> {
         let data_offset = reader.stream_position()?;
 
         // Read box size (4 bytes, big-endian)
@@ -306,7 +306,7 @@ impl Mp4Handler {
             size
         };
 
-        Ok(Mp4Box {
+        Ok(Mpeg4Box {
             size: actual_size,
             box_type,
             data_offset,
@@ -1361,7 +1361,7 @@ mod tests {
     fn test_read_xmp_no_xmp() {
         let mp4_data = create_minimal_mp4();
         let reader = Cursor::new(mp4_data);
-        let result = Mp4Handler::read_xmp(reader).unwrap();
+        let result = Mpeg4Handler::read_xmp(reader).unwrap();
         assert!(result.is_none());
     }
 
@@ -1369,7 +1369,7 @@ mod tests {
     fn test_invalid_mp4() {
         let invalid_data = vec![0x00, 0x01, 0x02, 0x03];
         let reader = Cursor::new(invalid_data);
-        let result = Mp4Handler::read_xmp(reader);
+        let result = Mpeg4Handler::read_xmp(reader);
         assert!(result.is_err());
     }
 
@@ -1386,11 +1386,11 @@ mod tests {
             .unwrap();
 
         // Write XMP
-        Mp4Handler::write_xmp(reader, &mut writer, &meta).unwrap();
+        Mpeg4Handler::write_xmp(reader, &mut writer, &meta).unwrap();
 
         // Read back XMP
         writer.set_position(0);
-        let result = Mp4Handler::read_xmp(writer).unwrap();
+        let result = Mpeg4Handler::read_xmp(writer).unwrap();
         assert!(result.is_some());
 
         let read_meta = result.unwrap();

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -16,8 +16,8 @@ pub use formats::gif::GifHandler;
 pub use formats::jpeg::JpegHandler;
 #[cfg(feature = "mp3")]
 pub use formats::mp3::Mp3Handler;
-#[cfg(feature = "mp4")]
-pub use formats::mp4::Mp4Handler;
+#[cfg(feature = "mpeg4")]
+pub use formats::mpeg4::Mpeg4Handler;
 #[cfg(feature = "png")]
 pub use formats::png::PngHandler;
 #[cfg(feature = "tiff")]

--- a/src/files/registry.rs
+++ b/src/files/registry.rs
@@ -17,8 +17,8 @@ pub enum Handler {
     Jpeg(crate::files::formats::jpeg::JpegHandler),
     #[cfg(feature = "mp3")]
     Mp3(crate::files::formats::mp3::Mp3Handler),
-    #[cfg(feature = "mp4")]
-    Mp4(crate::files::formats::mp4::Mp4Handler),
+    #[cfg(feature = "mpeg4")]
+    Mpeg4(crate::files::formats::mpeg4::Mpeg4Handler),
     #[cfg(feature = "pdf")]
     Pdf(crate::files::formats::pdf::PdfHandler),
     #[cfg(feature = "png")]
@@ -36,8 +36,8 @@ impl FileHandler for Handler {
             Handler::Jpeg(h) => h.can_handle(reader),
             #[cfg(feature = "mp3")]
             Handler::Mp3(h) => h.can_handle(reader),
-            #[cfg(feature = "mp4")]
-            Handler::Mp4(h) => h.can_handle(reader),
+            #[cfg(feature = "mpeg4")]
+            Handler::Mpeg4(h) => h.can_handle(reader),
             #[cfg(feature = "pdf")]
             Handler::Pdf(h) => h.can_handle(reader),
             #[cfg(feature = "png")]
@@ -58,8 +58,8 @@ impl FileHandler for Handler {
             Handler::Jpeg(h) => h.read_xmp(reader),
             #[cfg(feature = "mp3")]
             Handler::Mp3(h) => h.read_xmp(reader),
-            #[cfg(feature = "mp4")]
-            Handler::Mp4(h) => h.read_xmp(reader),
+            #[cfg(feature = "mpeg4")]
+            Handler::Mpeg4(h) => h.read_xmp(reader),
             #[cfg(feature = "pdf")]
             Handler::Pdf(h) => h.read_xmp(reader),
             #[cfg(feature = "png")]
@@ -82,8 +82,8 @@ impl FileHandler for Handler {
             Handler::Jpeg(h) => h.write_xmp(reader, writer, meta),
             #[cfg(feature = "mp3")]
             Handler::Mp3(h) => h.write_xmp(reader, writer, meta),
-            #[cfg(feature = "mp4")]
-            Handler::Mp4(h) => h.write_xmp(reader, writer, meta),
+            #[cfg(feature = "mpeg4")]
+            Handler::Mpeg4(h) => h.write_xmp(reader, writer, meta),
             #[cfg(feature = "pdf")]
             Handler::Pdf(h) => h.write_xmp(reader, writer, meta),
             #[cfg(feature = "png")]
@@ -101,8 +101,8 @@ impl FileHandler for Handler {
             Handler::Jpeg(h) => h.format_name(),
             #[cfg(feature = "mp3")]
             Handler::Mp3(h) => h.format_name(),
-            #[cfg(feature = "mp4")]
-            Handler::Mp4(h) => h.format_name(),
+            #[cfg(feature = "mpeg4")]
+            Handler::Mpeg4(h) => h.format_name(),
             #[cfg(feature = "pdf")]
             Handler::Pdf(h) => h.format_name(),
             #[cfg(feature = "png")]
@@ -120,8 +120,8 @@ impl FileHandler for Handler {
             Handler::Jpeg(h) => h.extensions(),
             #[cfg(feature = "mp3")]
             Handler::Mp3(h) => h.extensions(),
-            #[cfg(feature = "mp4")]
-            Handler::Mp4(h) => h.extensions(),
+            #[cfg(feature = "mpeg4")]
+            Handler::Mpeg4(h) => h.extensions(),
             #[cfg(feature = "pdf")]
             Handler::Pdf(h) => h.extensions(),
             #[cfg(feature = "png")]
@@ -160,8 +160,8 @@ impl HandlerRegistry {
         self.register(Handler::Jpeg(crate::files::formats::jpeg::JpegHandler));
         #[cfg(feature = "mp3")]
         self.register(Handler::Mp3(crate::files::formats::mp3::Mp3Handler));
-        #[cfg(feature = "mp4")]
-        self.register(Handler::Mp4(crate::files::formats::mp4::Mp4Handler));
+        #[cfg(feature = "mpeg4")]
+        self.register(Handler::Mpeg4(crate::files::formats::mpeg4::Mpeg4Handler));
         #[cfg(feature = "pdf")]
         self.register(Handler::Pdf(crate::files::formats::pdf::PdfHandler));
         #[cfg(feature = "png")]
@@ -264,7 +264,7 @@ mod tests {
         #[cfg(feature = "mp3")]
         assert!(registry.find_by_extension("mp3").is_some());
 
-        #[cfg(feature = "mp4")]
+        #[cfg(feature = "mpeg4")]
         {
             assert!(registry.find_by_extension("mp4").is_some());
             assert!(registry.find_by_extension("m4a").is_some());
@@ -323,12 +323,12 @@ mod tests {
         assert_eq!(handler.unwrap().format_name(), "MP3");
     }
 
-    #[cfg(feature = "mp4")]
+    #[cfg(feature = "mpeg4")]
     #[test]
-    fn test_find_by_detection_mp4() {
+    fn test_find_by_detection_mpeg4() {
         let registry = HandlerRegistry::new();
-        // MP4 ftyp box signature
-        let mp4_data = vec![
+        // MPEG4 ftyp box signature
+        let mpeg4_data = vec![
             0x00, 0x00, 0x00, 0x18, // box size
             0x66, 0x74, 0x79, 0x70, // 'ftyp'
             0x69, 0x73, 0x6F, 0x6D, // 'isom'
@@ -336,7 +336,7 @@ mod tests {
             0x69, 0x73, 0x6F, 0x6D, // compatible brand
             0x61, 0x76, 0x63, 0x31, // compatible brand
         ];
-        let mut reader = Cursor::new(mp4_data);
+        let mut reader = Cursor::new(mpeg4_data);
         let handler = registry.find_by_detection(&mut reader).unwrap();
         assert!(handler.is_some());
         assert_eq!(handler.unwrap().format_name(), "MP4");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@
 //!
 //! - `core` - Core XMP functionality (enabled by default)
 //! - `files` - File format support infrastructure (enabled by default)
-//! - `jpeg`, `png`, `tiff`, `mp3`, `gif`, `mp4` - Individual file format handlers
+//! - `jpeg`, `png`, `tiff`, `mp3`, `gif`, `mpeg4` - Individual file format handlers
 //! - `full-formats` - Enable all file format handlers (enabled by default)
 //! - `mutli-thread` - Multi-threaded runtime support (enabled by default)
 //! - `wasm` - WebAssembly JavaScript bindings (optional, enables wasm-bindgen integration)
@@ -212,7 +212,7 @@
 //! | TIFF   | .tif, .tiff | Yes | Yes |
 //! | MP3    | .mp3      | Yes | Yes |
 //! | GIF    | .gif      | Yes | Yes |
-//! | MP4    | .mp4      | Yes | Yes |
+//! | MPEG4  | .mp4, .m4a, .m4v | Yes | Yes |
 
 #[cfg(feature = "core")]
 pub mod core;


### PR DESCRIPTION
## Summary

Rename the `mp4` feature to `mpeg4` to align with the proper technical naming.

## Rationale

**MPEG-4 Part 12** (ISO 14496-12) is the official name for the container format that includes:
- `.mp4` - General video/audio
- `.m4a` - Audio only
- `.m4v` - Video (Apple)

This also aligns with the C++ XMP Toolkit naming convention (`MPEG4_Handler`, `kXMP_MPEG4File`).

## Changes

| Before | After |
|--------|-------|
| `mp4` feature | `mpeg4` feature |
| `mp4.rs` | `mpeg4.rs` |
| `Mp4Handler` | `Mpeg4Handler` |

## Migration

```toml
# Before
[dependencies]
xmpkit = { version = "0.1", features = ["mp4"] }

# After
[dependencies]
xmpkit = { version = "0.1", features = ["mpeg4"] }
```