### PR TITLE
feat(mpeg4): add native metadata reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ XMPKit is a pure Rust implementation of Adobe's XMP (Extensible Metadata Platfor
 - Zero-cost abstractions
 - Cross-platform support (iOS, Android, HarmonyOS, macOS, Windows, Linux, Wasm)
 
+### Optional Features
+
+| Feature | Description |
+|---------|-------------|
+| `optimize-file-layout` | Optimize file layout for streaming (MPEG4: UUID box after moov, before mdat) |
+
+**Note:** MPEG4/MOV files automatically reconcile QuickTime native metadata (©nam, ©ART, cprt, etc.) to XMP by default. Use `XmpOptions::only_xmp()` to skip reconciliation.
+
 ## Quick Start
 
 ```rust
@@ -107,14 +115,12 @@ For WebAssembly/JavaScript integration, see [WEBASSEMBLY.md](docs/WEBASSEMBLY.md
 <!-- markdownlint-disable MD056 -->
 | Platform | Architecture | File I/O | Memory I/O | Status |
 |----------|-------------|----------|------------|--------|
-| **Native Platforms** |||||
 | macOS | x86_64, arm64 | Yes | Yes | Fully supported |
 | Linux | x86_64, arm64 | Yes | Yes | Fully supported |
 | Windows | x86_64, arm64 | Yes | Yes | Fully supported |
 | iOS | arm64 | Yes | Yes | Fully supported |
 | Android | arm64, armv7, x86_64 | Yes | Yes | Fully supported |
 | HarmonyOS | arm64, armv7, x86_64 | Yes | Yes | Fully supported (use `ohos` feature for Node-API bindings) |
-| **Web Platforms** |||||
 | WebAssembly | wasm32 | No | Yes | Partial (use `from_bytes()` / `from_reader()`, see [WEBASSEMBLY](docs/WEBASSEMBLY.md)) |
 <!-- markdownlint-enable MD056 -->
 

--- a/examples/write_xmp.rs
+++ b/examples/write_xmp.rs
@@ -5,7 +5,7 @@
 
 use std::env;
 
-use xmpkit::{core::namespace::ns, register_namespace, ReadOptions, XmpFile, XmpMeta};
+use xmpkit::{core::namespace::ns, register_namespace, XmpFile, XmpMeta, XmpOptions};
 
 fn write_xmp_to_file() -> Result<(), Box<dyn std::error::Error>> {
     // Parse command-line arguments.
@@ -22,7 +22,7 @@ fn write_xmp_to_file() -> Result<(), Box<dyn std::error::Error>> {
 
     // Open the input file with for_update option (required for writing)
     let mut xmp_file = XmpFile::new();
-    xmp_file.open_with(input_path, ReadOptions::default().for_update())?;
+    xmp_file.open_with(input_path, XmpOptions::default().for_update())?;
 
     // Get existing XMP or create new metadata
     let mut xmp = xmp_file.get_xmp().cloned().unwrap_or_else(XmpMeta::new);

--- a/src/files/formats/gif.rs
+++ b/src/files/formats/gif.rs
@@ -10,7 +10,7 @@
 
 use crate::core::error::{XmpError, XmpResult};
 use crate::core::metadata::XmpMeta;
-use crate::files::handler::FileHandler;
+use crate::files::handler::{FileHandler, XmpOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 
 /// GIF file signature
@@ -51,7 +51,11 @@ impl FileHandler for GifHandler {
         }
     }
 
-    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>> {
+    fn read_xmp<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        _options: &XmpOptions,
+    ) -> XmpResult<Option<XmpMeta>> {
         Self::read_xmp(reader)
     }
 

--- a/src/files/formats/jpeg.rs
+++ b/src/files/formats/jpeg.rs
@@ -10,7 +10,7 @@
 
 use crate::core::error::{XmpError, XmpResult};
 use crate::core::metadata::XmpMeta;
-use crate::files::handler::FileHandler;
+use crate::files::handler::{FileHandler, XmpOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 
 /// JPEG segment markers
@@ -47,7 +47,11 @@ impl FileHandler for JpegHandler {
         Ok(header[0] == 0xFF && header[1] == MARKER_SOI)
     }
 
-    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>> {
+    fn read_xmp<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        _options: &XmpOptions,
+    ) -> XmpResult<Option<XmpMeta>> {
         Self::read_xmp(reader)
     }
 

--- a/src/files/formats/mp3.rs
+++ b/src/files/formats/mp3.rs
@@ -10,7 +10,7 @@
 
 use crate::core::error::{XmpError, XmpResult};
 use crate::core::metadata::XmpMeta;
-use crate::files::handler::FileHandler;
+use crate::files::handler::{FileHandler, XmpOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 
 /// ID3v2 tag header size (same for v2.2, v2.3, v2.4)
@@ -43,7 +43,11 @@ impl FileHandler for Mp3Handler {
         Ok(header == *b"ID3")
     }
 
-    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>> {
+    fn read_xmp<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        _options: &XmpOptions,
+    ) -> XmpResult<Option<XmpMeta>> {
         Self::read_xmp(reader)
     }
 

--- a/src/files/formats/pdf.rs
+++ b/src/files/formats/pdf.rs
@@ -12,7 +12,7 @@
 
 use crate::core::error::{XmpError, XmpResult};
 use crate::core::metadata::XmpMeta;
-use crate::files::handler::FileHandler;
+use crate::files::handler::{FileHandler, XmpOptions};
 use lopdf::{dictionary, Document, Object, Stream};
 use std::io::{Read, Seek, Write};
 
@@ -34,7 +34,11 @@ impl FileHandler for PdfHandler {
         Ok(header == PDF_SIGNATURE)
     }
 
-    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>> {
+    fn read_xmp<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        _options: &XmpOptions,
+    ) -> XmpResult<Option<XmpMeta>> {
         Self::read_xmp(reader)
     }
 

--- a/src/files/formats/png.rs
+++ b/src/files/formats/png.rs
@@ -10,7 +10,7 @@
 
 use crate::core::error::{XmpError, XmpResult};
 use crate::core::metadata::XmpMeta;
-use crate::files::handler::FileHandler;
+use crate::files::handler::{FileHandler, XmpOptions};
 use std::io::{Read, Seek, Write};
 
 /// PNG file signature
@@ -37,7 +37,11 @@ impl FileHandler for PngHandler {
         Ok(signature == PNG_SIGNATURE)
     }
 
-    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>> {
+    fn read_xmp<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        _options: &XmpOptions,
+    ) -> XmpResult<Option<XmpMeta>> {
         Self::read_xmp(reader)
     }
 

--- a/src/files/formats/tiff.rs
+++ b/src/files/formats/tiff.rs
@@ -10,7 +10,7 @@
 
 use crate::core::error::{XmpError, XmpResult};
 use crate::core::metadata::XmpMeta;
-use crate::files::handler::FileHandler;
+use crate::files::handler::{FileHandler, XmpOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 
 /// TIFF file header signatures
@@ -40,7 +40,11 @@ impl FileHandler for TiffHandler {
         Ok(header[0..4] == *TIFF_SIGNATURE_LE || header[0..4] == *TIFF_SIGNATURE_BE)
     }
 
-    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>> {
+    fn read_xmp<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        _options: &XmpOptions,
+    ) -> XmpResult<Option<XmpMeta>> {
         Self::read_xmp(reader)
     }
 

--- a/src/files/handler.rs
+++ b/src/files/handler.rs
@@ -7,6 +7,104 @@ use crate::core::error::XmpResult;
 use crate::core::metadata::XmpMeta;
 use std::io::{Read, Seek, Write};
 
+/// Options for XMP file operations.
+///
+/// Use the builder pattern to configure options. These options control how
+/// file handlers read and process XMP metadata.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use xmpkit::{XmpFile, XmpOptions};
+///
+/// let mut file = XmpFile::new();
+/// // Open for update with strict mode
+/// file.open_with("photo.jpg", XmpOptions::default().for_update().strict())?;
+/// // ... modify metadata ...
+/// file.try_close()?;
+/// # Ok::<(), xmpkit::XmpError>(())
+/// ```
+#[derive(Default, Clone, Copy, Debug)]
+pub struct XmpOptions {
+    /// Open for reading and writing (default: read-only)
+    pub for_update: bool,
+    /// Only the XMP is wanted, skip reconciliation with native metadata
+    pub only_xmp: bool,
+    /// Force use of the given handler (format)
+    pub force_given_handler: bool,
+    /// Be strict about only attempting to use the designated file handler
+    pub strict: bool,
+    /// Require the use of a smart handler
+    pub use_smart_handler: bool,
+    /// Force packet scanning (do not use smart handler)
+    pub use_packet_scanning: bool,
+    /// Only packet scan files "known" to need scanning
+    pub limited_scanning: bool,
+}
+
+impl XmpOptions {
+    /// Open for read-only access (default).
+    pub fn for_read(mut self) -> Self {
+        self.for_update = false;
+        self
+    }
+
+    /// Open for reading and writing.
+    ///
+    /// Files opened for update are written to only when closing.
+    pub fn for_update(mut self) -> Self {
+        self.for_update = true;
+        self
+    }
+
+    /// Only the XMP is wanted.
+    ///
+    /// This allows space/time optimizations by skipping reconciliation
+    /// with native metadata formats (e.g., QuickTime metadata in MPEG4).
+    pub fn only_xmp(mut self) -> Self {
+        self.only_xmp = true;
+        self
+    }
+
+    /// Force use of the given handler (format).
+    ///
+    /// Do not even verify the format.
+    pub fn force_given_handler(mut self) -> Self {
+        self.force_given_handler = true;
+        self
+    }
+
+    /// Be strict about only attempting to use the designated file handler.
+    ///
+    /// Do not fall back to other handlers.
+    pub fn strict(mut self) -> Self {
+        self.strict = true;
+        self
+    }
+
+    /// Require the use of a smart handler.
+    ///
+    /// Do not fall back to packet scanning.
+    pub fn use_smart_handler(mut self) -> Self {
+        self.use_smart_handler = true;
+        self
+    }
+
+    /// Force packet scanning.
+    ///
+    /// Do not use a smart handler.
+    pub fn use_packet_scanning(mut self) -> Self {
+        self.use_packet_scanning = true;
+        self
+    }
+
+    /// Only packet scan files "known" to need scanning.
+    pub fn limited_scanning(mut self) -> Self {
+        self.limited_scanning = true;
+        self
+    }
+}
+
 /// Trait for file format handlers
 ///
 /// All file format handlers (JPEG, PNG, TIFF, etc.) must implement this trait
@@ -32,13 +130,18 @@ pub trait FileHandler: Send + Sync {
     /// # Arguments
     ///
     /// * `reader` - A reader implementing `Read + Seek`
+    /// * `options` - Options controlling how XMP is read
     ///
     /// # Returns
     ///
     /// * `Ok(Some(XmpMeta))` if XMP metadata is found
     /// * `Ok(None)` if no XMP metadata is found
     /// * `Err(XmpError)` if an error occurs
-    fn read_xmp<R: Read + Seek>(&self, reader: &mut R) -> XmpResult<Option<XmpMeta>>;
+    fn read_xmp<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        options: &XmpOptions,
+    ) -> XmpResult<Option<XmpMeta>>;
 
     /// Write XMP metadata to a file
     ///

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -9,7 +9,7 @@ pub mod formats;
 pub mod handler;
 pub mod registry;
 
-pub use file::{ReadOptions, XmpFile};
+pub use file::XmpFile;
 #[cfg(feature = "gif")]
 pub use formats::gif::GifHandler;
 #[cfg(feature = "jpeg")]
@@ -23,4 +23,5 @@ pub use formats::png::PngHandler;
 #[cfg(feature = "tiff")]
 pub use formats::tiff::TiffHandler;
 pub use handler::FileHandler;
+pub use handler::XmpOptions;
 pub use registry::{default_registry, Handler, HandlerRegistry};

--- a/src/files/registry.rs
+++ b/src/files/registry.rs
@@ -4,7 +4,7 @@
 //! Handlers can be registered and looked up by file extension or format detection.
 
 use crate::core::error::XmpResult;
-use crate::files::handler::FileHandler;
+use crate::files::handler::{FileHandler, XmpOptions};
 use std::io::{Read, Seek, Write};
 
 /// Enum of supported file handlers
@@ -50,22 +50,23 @@ impl FileHandler for Handler {
     fn read_xmp<R: Read + Seek>(
         &self,
         reader: &mut R,
+        options: &XmpOptions,
     ) -> XmpResult<Option<crate::core::metadata::XmpMeta>> {
         match self {
             #[cfg(feature = "gif")]
-            Handler::Gif(h) => h.read_xmp(reader),
+            Handler::Gif(h) => h.read_xmp(reader, options),
             #[cfg(feature = "jpeg")]
-            Handler::Jpeg(h) => h.read_xmp(reader),
+            Handler::Jpeg(h) => h.read_xmp(reader, options),
             #[cfg(feature = "mp3")]
-            Handler::Mp3(h) => h.read_xmp(reader),
+            Handler::Mp3(h) => h.read_xmp(reader, options),
             #[cfg(feature = "mpeg4")]
-            Handler::Mpeg4(h) => h.read_xmp(reader),
+            Handler::Mpeg4(h) => h.read_xmp(reader, options),
             #[cfg(feature = "pdf")]
-            Handler::Pdf(h) => h.read_xmp(reader),
+            Handler::Pdf(h) => h.read_xmp(reader, options),
             #[cfg(feature = "png")]
-            Handler::Png(h) => h.read_xmp(reader),
+            Handler::Png(h) => h.read_xmp(reader, options),
             #[cfg(feature = "tiff")]
-            Handler::Tiff(h) => h.read_xmp(reader),
+            Handler::Tiff(h) => h.read_xmp(reader, options),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ pub use core::namespace::{
     get_global_namespace_uri, is_namespace_registered, ns, register_namespace,
 };
 #[cfg(feature = "files")]
-pub use files::{ReadOptions, XmpFile};
+pub use files::{XmpFile, XmpOptions};
 pub use types::qualifier::Qualifier;
 pub use types::value::XmpValue;
 pub use utils::datetime::XmpDateTime;

--- a/src/ohos/file.rs
+++ b/src/ohos/file.rs
@@ -1,6 +1,6 @@
 //! OpenHarmony bindings for XMP file operations
 
-use crate::files::file::ReadOptions as RustReadOptions;
+use crate::files::handler::XmpOptions as RustXmpOptions;
 use crate::ohos::error::xmp_error_to_ohos_error;
 use crate::ohos::meta::XmpMeta;
 use crate::XmpFile as RustXmpFile;
@@ -12,16 +12,16 @@ use napi_ohos::bindgen_prelude::*;
 /// Configure how XMP data is read and processed.
 #[derive(Default)]
 #[napi]
-pub struct ReadOptions {
-    inner: RustReadOptions,
+pub struct XmpOptions {
+    inner: RustXmpOptions,
 }
 
 #[napi]
-impl ReadOptions {
+impl XmpOptions {
     /// Create default options
     #[napi(constructor)]
-    pub fn new() -> ReadOptions {
-        ReadOptions::default()
+    pub fn new() -> XmpOptions {
+        XmpOptions::default()
     }
 
     /// Force packet scanning (do not use smart handler)
@@ -77,7 +77,7 @@ impl XmpFile {
     }
 
     /// Load XMP from file bytes with options
-    pub fn from_bytes_with(&mut self, data: Buffer, options: &ReadOptions) -> Result<()> {
+    pub fn from_bytes_with(&mut self, data: Buffer, options: &XmpOptions) -> Result<()> {
         self.inner
             .from_bytes_with(data.as_ref(), options.inner)
             .map_err(|e| Error::from_reason(format!("{}", xmp_error_to_ohos_error(e))))

--- a/src/ohos/mod.rs
+++ b/src/ohos/mod.rs
@@ -40,7 +40,7 @@ mod value;
 
 pub use datetime::XmpDateTime;
 pub use error::{XmpError, XmpErrorKind};
-pub use file::{ReadOptions, XmpFile};
+pub use file::{XmpFile, XmpOptions};
 pub use meta::XmpMeta;
 pub use namespace::{
     get_all_registered_namespaces, get_builtin_namespace_uris, get_namespace_prefix,

--- a/src/wasm/file.rs
+++ b/src/wasm/file.rs
@@ -1,6 +1,6 @@
 //! WebAssembly bindings for XMP file operations
 
-use crate::files::file::ReadOptions as RustReadOptions;
+use crate::files::handler::XmpOptions as RustXmpOptions;
 use crate::wasm::error::{xmp_error_to_wasm_error, XmpError};
 use crate::wasm::meta::XmpMeta;
 use crate::XmpFile as RustXmpFile;
@@ -19,7 +19,7 @@ use wasm_bindgen::prelude::*;
 /// const meta = file.get_xmp();
 ///
 /// // For read and write operations
-/// const options = new ReadOptions();
+/// const options = new XmpOptions();
 /// options.for_update();  // Required if you want to write changes
 /// file.from_bytes_with(data, options);
 /// // ... modify metadata ...
@@ -27,16 +27,16 @@ use wasm_bindgen::prelude::*;
 /// ```
 #[derive(Default)]
 #[wasm_bindgen]
-pub struct ReadOptions {
-    inner: RustReadOptions,
+pub struct XmpOptions {
+    inner: RustXmpOptions,
 }
 
 #[wasm_bindgen]
-impl ReadOptions {
+impl XmpOptions {
     /// Create default options
     #[wasm_bindgen(constructor)]
-    pub fn new() -> ReadOptions {
-        ReadOptions::default()
+    pub fn new() -> XmpOptions {
+        XmpOptions::default()
     }
 
     /// Open for reading and writing
@@ -82,7 +82,7 @@ impl ReadOptions {
 /// # Example
 ///
 /// ```javascript
-/// import init, { XmpFile, ReadOptions } from './pkg/xmpkit.js';
+/// import init, { XmpFile, XmpOptions } from './pkg/xmpkit.js';
 /// await init();
 ///
 /// // Read-only mode (memory efficient)
@@ -92,7 +92,7 @@ impl ReadOptions {
 ///
 /// // Read and write mode
 /// const file2 = new XmpFile();
-/// const options = new ReadOptions();
+/// const options = new XmpOptions();
 /// options.for_update();  // Required for write_to_bytes()
 /// file2.from_bytes_with(fileData, options);
 /// const meta2 = file2.get_xmp();
@@ -132,11 +132,11 @@ impl XmpFile {
     /// # Example
     ///
     /// ```javascript
-    /// const options = new ReadOptions();
+    /// const options = new XmpOptions();
     /// options.use_packet_scanning();
     /// file.from_bytes_with(data, options);
     /// ```
-    pub fn from_bytes_with(&mut self, data: &[u8], options: &ReadOptions) -> Result<(), XmpError> {
+    pub fn from_bytes_with(&mut self, data: &[u8], options: &XmpOptions) -> Result<(), XmpError> {
         self.inner
             .from_bytes_with(data, options.inner)
             .map_err(xmp_error_to_wasm_error)

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -39,7 +39,7 @@ mod value;
 
 pub use datetime::XmpDateTime;
 pub use error::{XmpError, XmpErrorKind};
-pub use file::{ReadOptions, XmpFile};
+pub use file::{XmpFile, XmpOptions};
 pub use meta::XmpMeta;
 pub use namespace::{
     get_all_registered_namespaces, get_builtin_namespace_uris, get_namespace_prefix,

--- a/tests/xmp_file.rs
+++ b/tests/xmp_file.rs
@@ -68,7 +68,7 @@ mod wasm_compatible_tests {
 /// Verifies that XMP can be read without loading entire file into memory
 mod streaming_read_tests {
     use super::*;
-    use xmpkit::ReadOptions;
+    use xmpkit::XmpOptions;
 
     #[test]
     fn read_only_mode_does_not_store_file_data() {
@@ -98,7 +98,7 @@ mod streaming_read_tests {
         // Error message should indicate the issue
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("ReadOptions::for_update"),
+            err_msg.contains("XmpOptions::for_update"),
             "Error should suggest using for_update()"
         );
     }
@@ -115,7 +115,7 @@ mod streaming_read_tests {
 
         // Open with for_update option
         let mut file = XmpFile::new();
-        file.from_bytes_with(&file_data, ReadOptions::default().for_update())
+        file.from_bytes_with(&file_data, XmpOptions::default().for_update())
             .unwrap();
 
         // Verify we can read XMP
@@ -149,7 +149,7 @@ mod streaming_read_tests {
         let mut file = XmpFile::new();
         file.from_bytes_with(
             &file_data,
-            ReadOptions::default().use_packet_scanning().for_update(),
+            XmpOptions::default().use_packet_scanning().for_update(),
         )
         .unwrap();
 
@@ -176,7 +176,7 @@ mod streaming_read_tests {
 
         // Open with packet scanning only (read-only)
         let mut file = XmpFile::new();
-        file.from_bytes_with(&file_data, ReadOptions::default().use_packet_scanning())
+        file.from_bytes_with(&file_data, XmpOptions::default().use_packet_scanning())
             .unwrap();
 
         // Writing should fail because file_data is not stored


### PR DESCRIPTION
## Summary

- Add automatic reconciliation of QuickTime native metadata to XMP for MPEG4/MOV files, matching the behavior of Adobe's C++ XMP Toolkit
- Rename `ReadOptions` to `XmpOptions` and add `options` parameter to `FileHandler::read_xmp` trait method
- Add `XmpOptions::only_xmp()` to disable reconciliation and read only XMP metadata

## Changes

### API Changes
- `ReadOptions` → `XmpOptions` (breaking change)
- `FileHandler::read_xmp` now accepts `&XmpOptions` parameter

### Native Metadata Mapping
| QuickTime Box | XMP Property |
|---------------|--------------|
| ©nam | dc:title |
| ©ART | dc:creator |
| ©wrt | dc:creator |
| ©alb | xmpDM:album |
| ©day | xmp:CreateDate |
| ©cmt | dc:description |
| ©gen | xmpDM:genre |
| cprt/©cpy | dc:rights |

### Behavior
- Reconciliation is **enabled by default** (matching C++ XMP Toolkit)
- Use `XmpOptions::only_xmp()` to skip reconciliation
- Only properties not already present in XMP are reconciled

## Test plan
- [x] Unit tests for language code conversion
- [x] Unit tests for reconciliation logic
- [x] Integration test with real MOV file containing QuickTime metadata
- [x] Verify `only_xmp()` correctly skips reconciliation
- [x] All existing tests pass