### PR TITLE
fix(web): use exported wasm options type

### DIFF
--- a/web/src/composables/useXmp.ts
+++ b/web/src/composables/useXmp.ts
@@ -4,7 +4,7 @@ import { ElMessage } from 'element-plus'
 import {
   XmpFile,
   XmpMeta,
-  ReadOptions,
+  XmpOptions,
   Namespace,
   namespace_uri,
   register_namespace,
@@ -141,7 +141,7 @@ export function useXmp() {
 
           let loadSuccess = false
           try {
-            const options1 = new ReadOptions()
+            const options1 = new XmpOptions()
             options1.for_update() // Required for write_to_bytes() later
             options1.use_smart_handler()
             options1.only_xmp()
@@ -150,7 +150,7 @@ export function useXmp() {
           } catch (error) {
             console.log('Smart handler failed, trying packet scanning...', error)
             try {
-              const options2 = new ReadOptions()
+              const options2 = new XmpOptions()
               options2.for_update() // Required for write_to_bytes() later
               options2.use_packet_scanning()
               xmpFileInstance.from_bytes_with(fileData, options2)
@@ -349,7 +349,7 @@ export function useXmp() {
       let loadSuccess = false
 
       try {
-        const options1 = new ReadOptions()
+        const options1 = new XmpOptions()
         options1.for_update() // Required for write_to_bytes() later
         options1.use_smart_handler()
         options1.only_xmp()
@@ -357,7 +357,7 @@ export function useXmp() {
         loadSuccess = true
       } catch {
         try {
-          const options2 = new ReadOptions()
+          const options2 = new XmpOptions()
           options2.for_update() // Required for write_to_bytes() later
           options2.use_packet_scanning()
           xmpFileInstance.from_bytes_with(originalFileData.value, options2)
@@ -429,4 +429,3 @@ export function useXmp() {
     getPropertyValue,
   }
 }
-

--- a/web/src/utils/wasm.ts
+++ b/web/src/utils/wasm.ts
@@ -1,7 +1,7 @@
 import init, {
   XmpFile,
   XmpMeta,
-  ReadOptions,
+  XmpOptions,
   Namespace,
   namespace_uri,
   register_namespace,
@@ -33,7 +33,7 @@ export async function initWasm() {
 export {
   XmpFile,
   XmpMeta,
-  ReadOptions,
+  XmpOptions,
   Namespace,
   namespace_uri,
   register_namespace,
@@ -43,4 +43,3 @@ export {
   get_all_registered_namespaces,
   get_builtin_namespace_uris
 }
-


### PR DESCRIPTION
## Summary
- Replace the stale web import of `ReadOptions` with the wasm-bindgen exported `XmpOptions` class.
- Update option construction in the XMP composable to match the generated wasm package API.

## Verification
- `npm run build-wasm`
- `npm run build-only -- --base /xmpkit/`
- `npm run type-check`
