### PR TITLE
Fix RDF Description parsing and resolve clippy warnings

### DIFF
--- a/examples/read_xmp.rs
+++ b/examples/read_xmp.rs
@@ -31,19 +31,15 @@ fn read_xmp_from_file() -> Result<(), Box<dyn std::error::Error>> {
 
     // Display the simple property "CreatorTool" by providing
     // the namespace URI and the name of the property.
-    if let Some(creator_tool) = xmp.get_property(ns::XMP, "CreatorTool") {
-        if let XmpValue::String(value) = creator_tool {
-            println!("CreatorTool = {}", value);
-        }
+    if let Some(XmpValue::String(value)) = xmp.get_property(ns::XMP, "CreatorTool") {
+        println!("CreatorTool = {}", value);
     }
 
     // Display the first element of the `creator` array.
     if let Some(size) = xmp.get_array_size(ns::DC, "creator") {
         if size > 0 {
-            if let Some(first_creator) = xmp.get_array_item(ns::DC, "creator", 0) {
-                if let XmpValue::String(value) = first_creator {
-                    println!("dc:creator = {}", value);
-                }
+            if let Some(XmpValue::String(value)) = xmp.get_array_item(ns::DC, "creator", 0) {
+                println!("dc:creator = {}", value);
             }
         } else {
             println!("No creator found");
@@ -57,10 +53,8 @@ fn read_xmp_from_file() -> Result<(), Box<dyn std::error::Error>> {
     // instead follows Rust's convention of being 0-based.
     if let Some(size) = xmp.get_array_size(ns::DC, "subject") {
         for index in 0..size {
-            if let Some(subject) = xmp.get_array_item(ns::DC, "subject", index) {
-                if let XmpValue::String(value) = subject {
-                    println!("dc:subject[{}] = {}", index, value);
-                }
+            if let Some(XmpValue::String(value)) = xmp.get_array_item(ns::DC, "subject", index) {
+                println!("dc:subject[{}] = {}", index, value);
             }
         }
     }
@@ -83,10 +77,8 @@ fn read_xmp_from_file() -> Result<(), Box<dyn std::error::Error>> {
 
     // Discover if the Exif Flash structure is available. If so, display the
     // flash status at the time the photograph was taken.
-    if let Some(value) = xmp.get_struct_field(ns::EXIF, "Flash", "Fired") {
-        if let XmpValue::String(s) = value {
-            println!("Flash Used = {}", s);
-        }
+    if let Some(XmpValue::String(s)) = xmp.get_struct_field(ns::EXIF, "Flash", "Fired") {
+        println!("Flash Used = {}", s);
     }
 
     Ok(())

--- a/src/core/metadata/mod.rs
+++ b/src/core/metadata/mod.rs
@@ -1583,7 +1583,7 @@ mod tests {
         assert_eq!(retrieved_dt.hour, 10);
         assert_eq!(retrieved_dt.minute, 30);
         assert_eq!(retrieved_dt.second, 0);
-        assert_eq!(retrieved_dt.has_timezone, true);
+        assert!(retrieved_dt.has_timezone);
         assert_eq!(retrieved_dt.tz_sign, 0);
     }
 

--- a/src/core/parser.rs
+++ b/src/core/parser.rs
@@ -409,7 +409,22 @@ impl XmpParser {
 
     /// Check if element name is a Description element
     fn is_description_element(&self, name: &str) -> bool {
-        name == "Description" || name.ends_with(":Description")
+        let colon_pos = name.find(':');
+        let (prefix, local_name) = if let Some(pos) = colon_pos {
+            (&name[..pos], &name[pos + 1..])
+        } else {
+            ("", name)
+        };
+
+        if local_name != "Description" {
+            return false;
+        }
+
+        if let Some(ns_uri) = self.namespaces.get_uri(prefix) {
+            ns_uri == crate::core::namespace::ns::RDF
+        } else {
+            prefix == "rdf" || (prefix.is_empty() && name == "Description")
+        }
     }
 
     /// Check if element name is an array container (Seq, Bag, Alt)

--- a/src/files/formats/svg.rs
+++ b/src/files/formats/svg.rs
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_can_handle_valid_svg() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = create_test_svg();
         let mut cursor = Cursor::new(svg.as_bytes());
 
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_can_handle_svg_with_xmp() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = create_test_svg_with_xmp();
         let mut cursor = Cursor::new(svg.as_bytes());
 
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn test_can_handle_invalid() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
 
         // Not SVG - HTML
         let mut cursor = Cursor::new(b"<html><body>Hello</body></html>");
@@ -493,7 +493,7 @@ mod tests {
 
     #[test]
     fn test_read_xmp_no_xmp() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = create_test_svg();
         let mut cursor = Cursor::new(svg.as_bytes());
 
@@ -504,7 +504,7 @@ mod tests {
 
     #[test]
     fn test_read_xmp_with_xmp() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = create_test_svg_with_xmp();
         let mut cursor = Cursor::new(svg.as_bytes());
 
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_write_xmp_new() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = create_test_svg();
         let mut reader = Cursor::new(svg.as_bytes());
         let mut writer = Cursor::new(Vec::new());
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_write_xmp_replace() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = create_test_svg_with_xmp();
         let mut reader = Cursor::new(svg.as_bytes());
         let mut writer = Cursor::new(Vec::new());
@@ -566,14 +566,14 @@ mod tests {
 
     #[test]
     fn test_format_info() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         assert_eq!(handler.format_name(), "SVG");
         assert!(handler.extensions().contains(&"svg"));
     }
 
     #[test]
     fn test_handles_comments() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = r#"<?xml version="1.0"?>
 <!-- This is a comment -->
 <svg xmlns="http://www.w3.org/2000/svg">
@@ -593,7 +593,7 @@ mod tests {
 
     #[test]
     fn test_handles_cdata() {
-        let handler = SvgHandler::default();
+        let handler = SvgHandler;
         let svg = r#"<?xml version="1.0"?>
 <svg xmlns="http://www.w3.org/2000/svg">
   <script><![CDATA[

--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -518,8 +518,8 @@ mod tests {
         let dt = XmpDateTime::parse("2023").unwrap();
         assert_eq!(dt.year, 2023);
         assert_eq!(dt.month, 0);
-        assert_eq!(dt.has_date, true);
-        assert_eq!(dt.has_time, false);
+        assert!(dt.has_date);
+        assert!(!dt.has_time);
     }
 
     #[test]
@@ -536,7 +536,7 @@ mod tests {
         assert_eq!(dt.year, 2023);
         assert_eq!(dt.month, 12);
         assert_eq!(dt.day, 25);
-        assert_eq!(dt.has_time, false);
+        assert!(!dt.has_time);
     }
 
     #[test]
@@ -548,20 +548,20 @@ mod tests {
         assert_eq!(dt.hour, 10);
         assert_eq!(dt.minute, 30);
         assert_eq!(dt.second, 0);
-        assert_eq!(dt.has_time, true);
+        assert!(dt.has_time);
     }
 
     #[test]
     fn test_parse_with_timezone_utc() {
         let dt = XmpDateTime::parse("2023-12-25T10:30:00Z").unwrap();
-        assert_eq!(dt.has_timezone, true);
+        assert!(dt.has_timezone);
         assert_eq!(dt.tz_sign, 0);
     }
 
     #[test]
     fn test_parse_with_timezone_offset() {
         let dt = XmpDateTime::parse("2023-12-25T10:30:00+08:00").unwrap();
-        assert_eq!(dt.has_timezone, true);
+        assert!(dt.has_timezone);
         assert_eq!(dt.tz_sign, 1);
         assert_eq!(dt.tz_hour, 8);
         assert_eq!(dt.tz_minute, 0);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,8 +1,2 @@
-//! Integration tests for xmpkit
-//!
-//! These tests verify the library works correctly with real files and
-//! are compatible with the original xmp-toolkit-rs tests.
-
-mod fixtures;
-mod xmp_file;
-mod xmp_meta;
+// This file is intentionally left empty to avoid duplicate module compilation warnings from clippy.
+// The tests are run as standalone crates in tests/xmp_file.rs and tests/xmp_meta.rs.

--- a/tests/xmp_meta.rs
+++ b/tests/xmp_meta.rs
@@ -168,6 +168,35 @@ mod from_str {
     }
 
     #[test]
+    fn parse_mwg_regions_with_description() {
+        let xmp_str = r#"<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:mwg-rs="http://www.metadataworkinggroup.com/schemas/regions/">
+   <mwg-rs:Regions>
+    <mwg-rs:RegionList>
+     <rdf:Seq>
+      <rdf:li>
+       <mwg-rs:Description>This is a region description</mwg-rs:Description>
+      </rdf:li>
+     </rdf:Seq>
+    </mwg-rs:RegionList>
+   </mwg-rs:Regions>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>"#;
+
+        let meta = xmp_str.parse::<XmpMeta>().unwrap();
+        let path = "Regions/mwg-rs:RegionList[1]/mwg-rs:Description";
+        let ns = "http://www.metadataworkinggroup.com/schemas/regions/";
+
+        assert_eq!(
+            meta.get_property(ns, path),
+            Some(XmpValue::String("This is a region description".to_string()))
+        );
+    }
+
+    #[test]
     fn invalid_xml() {
         let result = "not valid xml".parse::<XmpMeta>();
         assert!(result.is_err());


### PR DESCRIPTION
* Fix `is_description_element` in `src/core/parser.rs` to verify the namespace URI of the element.
* Add regression test `parse_mwg_regions_with_description` to verify `mwg-rs:Description` is not incorrectly parsed as RDF Description.
* Fix a bunch of clippy warning in format handlers and examples along the way.

Fixes: #105
