### PR TITLE
ci: add semantic PR title check

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,34 @@
+name: Semantic PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pr-title:
+    name: Semantic PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to validate pull request titles with Conventional Commits
- explicitly allow the shared commit types without requiring scopes

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/semantic-pr-title.yml'); puts 'ok'"